### PR TITLE
Exclude markdown documents from pre-commit trailing whitespace rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.4.0
     hooks:
       - id: trailing-whitespace
+        exclude: '\.md$'
       - id: name-tests-test
       - id: check-docstring-first
       - id: check-executables-have-shebangs

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -2,7 +2,7 @@
 
 ## Testing Framework
 
-We utilize `pytest` along with the `pytest-flask` plugin to facilitate our testing.
+We utilize `pytest` along with the `pytest-flask` plugin to facilitate our testing.  
 
 ### Configuration with `conftest.py`
 


### PR DESCRIPTION
<!---
Please write your PR name in the present imperative tense. Examples of present imperative tense are:
"Fix issue in the dispatcher where…", "Improve our handling of…", etc."

For more information on Pull Requests, you can reference here:
https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute
-->
## Describe your changes

This PR updates the pre-commit configuration to allow trailing whitespace in Markdown files.

## Checklist before requesting a review
- [x] pre-commit run --all-files (run before pushing)
- [x] pytest if applicable
- [ ] Link issue
- [ ] Update relevant documentation if applicable: doc strings, readme, poetry.
