### PR TITLE
Adapted legal flow format to health page

### DIFF
--- a/new_arrivals_chi/app/main.py
+++ b/new_arrivals_chi/app/main.py
@@ -2,8 +2,8 @@
 Project: new_arrivals_chi
 File name: main.py
 Associated Files:
-    Templates: base.html, home.html, legal.html, profile.html,
-    login.html, info.html
+    Templates: base.html, home.html, legal.html, health.html,
+    health_search.html, profile.html, login.html, info.html
 
 Runs primary flask application for Chicago's new arrivals' portal.
 
@@ -13,8 +13,8 @@ Methods:
     * legal - Route to legal portion of application.
 
 Last updated:
-@Author: Madeleine Roberts @MadeleineKRoberts
-@Date: 04/25/2024
+@Author: Summer Long @Sumslong
+@Date: 05/03/2024
 
 Creation:
 @Author: Summer Long @Sumslong
@@ -70,7 +70,7 @@ def profile():
 def legal():
     """
     Establishes route for the legal page. This route is accessible
-    within the 'legal' button in the navigation bar.
+    within the 'legal' button on the home page.
 
     Returns:
         Renders main legal page.
@@ -78,6 +78,33 @@ def legal():
 
     language = request.args.get("lang", "en")
     return render_template("legal.html", language=language)
+
+
+@main.route("/health")
+def health():
+    """
+    Establishes route for the health page. This route is accessible
+    within the 'health' button on the home page.
+
+    Returns:
+        Renders main health page.
+    """
+
+    language = request.args.get("lang", "en")
+    return render_template("health.html", language=language)
+
+
+@main.route("/health/search")
+def health_search():
+    """
+    Establishes route for the health search page. This route is accessible
+    by selecting 'Receive Assistance Now' on the health page.
+
+    Returns:
+        Renders the health search page.
+    """
+    language = request.args.get("lang", "en")
+    return render_template("health_search.html", language=language)
 
 
 @main.route("/info")

--- a/new_arrivals_chi/app/static/css/main.css
+++ b/new_arrivals_chi/app/static/css/main.css
@@ -107,6 +107,8 @@ title {
     margin-bottom: 20px;
     text-align: center;
     width: 100%;
+    margin-left: 20px;
+    margin-right: 20px;
 }
 
 .box-title {

--- a/new_arrivals_chi/app/templates/health.html
+++ b/new_arrivals_chi/app/templates/health.html
@@ -1,0 +1,40 @@
+<!--
+Project: new_arrivals_chi
+File name: health.html
+Associated Files:
+    base.html, main.py
+
+Landing page for user to navigate through health information.
+
+Creation:
+@Author: Summer Long @sumslong
+@Date: 05/03/2024
+
+Contributors:
+Summer Long @sumslong
+-->
+{% extends "base.html" %}
+
+{% block content %}
+
+    <form action="/health" method="GET">
+        <button type="submit" class="language-button">{{ 'Español' if language == 'en' else 'English' }}</button>
+        <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' }}">
+    </form>
+    <div class="box">
+        <div class="box-big-title">Health Information</div>
+        <div class="box-title">I want to...</div>
+        <div class="button-container">
+            <button class="button orange" onclick="navigateTo('/health/search', '{{ language }}')">
+                {{ 'Ayudame Ahora' if language == 'es' else 'Receive Assistance Now' }}
+              </button>              
+            <button class="button green">Learn More About Resources</button>
+            <button class="yellow-button">Something else</button>
+            <p class="bottom-left">
+                <a href="/">{{ '<    ' if language == 'es' else '< Back' }}</a>
+            </p>
+            <p>
+        </div>
+
+    </div>
+{% endblock %}

--- a/new_arrivals_chi/app/templates/health.html
+++ b/new_arrivals_chi/app/templates/health.html
@@ -27,7 +27,7 @@ Summer Long @sumslong
         <div class="button-container">
             <button class="button orange" onclick="navigateTo('/health/search', '{{ language }}')">
                 {{ 'Ayudame Ahora' if language == 'es' else 'Receive Assistance Now' }}
-              </button>              
+              </button>
             <button class="button green">Learn More About Resources</button>
             <button class="yellow-button">Something else</button>
             <p class="bottom-left">

--- a/new_arrivals_chi/app/templates/health_search.html
+++ b/new_arrivals_chi/app/templates/health_search.html
@@ -23,4 +23,3 @@ Summer Long @sumslong
 </form>
 <h1>Placeholder for search interface</h1>
 {% endblock %}
-

--- a/new_arrivals_chi/app/templates/health_search.html
+++ b/new_arrivals_chi/app/templates/health_search.html
@@ -1,0 +1,26 @@
+<!--
+Project: new_arrivals_chi
+File name: health.html
+Associated Files:
+    base.html, main.py, health.html
+
+Search interface for health resources for a user.
+
+Creation:
+@Author: Summer Long @sumslong
+@Date: 05/03/2024
+
+Contributors:
+Summer Long @sumslong
+-->
+
+{% extends "base.html" %}
+
+{% block content %}
+<form action="/health/search" method="GET">
+    <button type="submit" class="language-button">{{ 'Español' if language == 'en' else 'English' }}</button>
+    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' }}">
+</form>
+<h1>Placeholder for search interface</h1>
+{% endblock %}
+

--- a/new_arrivals_chi/app/templates/home.html
+++ b/new_arrivals_chi/app/templates/home.html
@@ -23,7 +23,7 @@ Madeleine Roberts @MadeleineKRoberts
     <p>{{ 'Por favor haz click abajo para comenzar:' if language == 'es' else 'Please click below to begin:'}}</p>
     <div class="home-button-container">
         <button class="button button-blue" onclick="navigateTo('/legal', '{{ language }}')">{{ 'Legal' if language == 'es' else 'Legal' }}</button>
-        <button class="button button-yellow" onclick="window.location.href='/health'">{{ 'Salud' if language == 'es' else 'Health' }}</button>
+        <button class="button button-yellow" onclick="navigateTo('/health', '{{ language }}')">{{ 'Salud' if language == 'es' else 'Health' }}</button>
         <button class="button button-green" onclick="window.location.href='/food'">{{ 'Comida' if language == 'es' else 'Food' }}</button>
     </div>
 {% endblock %}

--- a/tests/app_home_test.py
+++ b/tests/app_home_test.py
@@ -34,7 +34,7 @@ def test_home_page_button_links(client):
     response = client.get(url_for("main.home"))
     html_content = response.data.decode("utf-8")
     assert "navigateTo('/legal', 'en')" in html_content
-    assert "window.location.href='/health'" in html_content
+    assert "navigateTo('/health', 'en')" in html_content
     assert "window.location.href='/food'" in html_content
 
     # Test Spanish links

--- a/tests/app_home_test.py
+++ b/tests/app_home_test.py
@@ -41,5 +41,5 @@ def test_home_page_button_links(client):
     response = client.get(url_for("main.home", lang="es"))
     html_content = response.data.decode("utf-8")
     assert "navigateTo('/legal', 'es')" in html_content
-    assert "navigateTo('/health, 'es')" in html_content
+    assert "navigateTo('/health', 'es')" in html_content
     assert "window.location.href='/food'" in html_content

--- a/tests/app_home_test.py
+++ b/tests/app_home_test.py
@@ -41,5 +41,5 @@ def test_home_page_button_links(client):
     response = client.get(url_for("main.home", lang="es"))
     html_content = response.data.decode("utf-8")
     assert "navigateTo('/legal', 'es')" in html_content
-    assert "window.location.href='/health'" in html_content
+    assert "navigateTo('/health, 'es')" in html_content
     assert "window.location.href='/food'" in html_content


### PR DESCRIPTION
## Describe your changes

This PR adopts the legal flow format to the health page, creating two buttons: one that will branch into a static page with resources, and one that will branch into a filtering interface using the database. It also creates a placeholder page for the search interface.

Files changed and created:
- main.css, to slightly amend the box to better suit health information
- health.html, created and adapted from legal.html
- health_search.html, created as a placeholder 
- app_home_test.py, to accommodate for the addition of health.html with language translation

Pytest is failing, but will pass once change to pytest is accepted in this PR:

`assert "window.location.href='/health'" in html_content` becomes `assert "navigateTo('/health', 'es') in html_content`

Accepting this PR closes #97.

## Non-obvious technical information

Aside from small text added to ensure translation features work, health.html still needs translation.

## Checklist before requesting a review
- [x] pre-commit run --all-files (run before pushing)
- [ ] pytest if applicable
- [x] Link issue
- [x] Update relevant documentation if applicable: doc strings, readme, poetry.
