### PR TITLE
Add script to tests/ that creates a fake database

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
         exclude: '\.md$'
       - id: name-tests-test
+        exclude: 'setup_fake_db.py'
       - id: check-docstring-first
       - id: check-executables-have-shebangs
       - id: check-json

--- a/new_arrivals_chi/app/utils.py
+++ b/new_arrivals_chi/app/utils.py
@@ -1,4 +1,7 @@
 import re
+import os
+import logging
+from datetime import datetime
 
 
 # Reference: https://docs.kickbox.com/docs/python-validate-an-email-address
@@ -16,3 +19,28 @@ def validate_password(password):
     no_space = re.search(r"\s", password) is None
 
     return len(password) >= 8 and valid_characters and no_space
+
+
+def setup_logger(name):
+    """Create a logger for recording the output of the script."""
+    log_directory = "logs"
+    if not os.path.exists(log_directory):
+        os.makedirs(log_directory)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    log_filename = f"{name}_{timestamp}.log"
+    log_path = os.path.join(log_directory, log_filename)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    file_handler = logging.FileHandler(log_path)
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    return logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ flask-login = "^0.6.3"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py", "*_test.py"]
+addopts = "--ignore=tests/setup_fake_db.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,14 @@ def app():
         "PREFERRED_URL_SCHEME": "http",
         "TESTING": True,
         "DEBUG": False,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"  # Ensure this uses a separate test database
     }
     app = create_app(config_override=test_config)
     with app.app_context():
+        db.create_all()
         yield app
+        db.session.remove()
+        db.drop_all()
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def app():
         "PREFERRED_URL_SCHEME": "http",
         "TESTING": True,
         "DEBUG": False,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"  # Ensure this uses a separate test database
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
     }
     app = create_app(config_override=test_config)
     with app.app_context():

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -49,32 +49,41 @@ def create_fake_user(organization):
     )
 
 
-def create_fake_data(num_users, db, logger):
-    """Generate fake data for testing by creating multiple users
-    and orgs with their locations and hours.
+def create_fake_data(num_users, database, logger):
+    """
+    Generate fake data for testing by creating multiple users
+    and organizations with their locations and hours.
+    Assumes that the database schema is already created and managed by the test fixture.
+
+    Parameters:
+    num_users (int): The number of users to create
+    database (SQLAlchemy): The database object to interact with the database
+    logger (Logger): The logger object to log messages
+
+    Returns:
+    None
     """
     logger.info("Starting to create fake data")
     try:
-        db.create_all()
-
         for _ in range(num_users):
             org = create_fake_organization()
-            db.session.add(org)
+            database.session.add(org)
 
             initial_user = create_fake_user(org)
-            db.session.add(initial_user)
+            database.session.add(initial_user)
 
             location = create_fake_location(initial_user.id)
-            db.session.add(location)
+            database.session.add(location)
 
             hours = create_fake_hours(initial_user.id)
-            db.session.add(hours)
-            db.session.commit()
-            logger.info(
-                f"Added org, user, location & hours for user {initial_user.id}"
-            )
+            database.session.add(hours)
+
+        database.session.commit()
+        logger.info(
+            f"Added org, user, location & hours for user {initial_user.id}"
+        )
     except Exception as e:
-        db.session.rollback()
+        database.session.rollback()
         logger.error(f"Error creating data: {e}, rolling back changes")
     else:
         logger.info("Fake data creation completed successfully")

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -53,7 +53,6 @@ def create_fake_data(num_users, database, logger):
     """
     Generate fake data for testing by creating multiple users
     and organizations with their locations and hours.
-    Assumes that the database schema is already created and managed by the test fixture.
 
     Parameters:
     num_users (int): The number of users to create

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -22,8 +22,9 @@ Test files are organized by their respective application components.
 ## Database Operation Tests
 
 The `db_test.py` file focuses on testing database operations and consistency across our application.
-
 It utilizes fixtures for the app, logger, and database and ensures all tests run within the application context.
+
+The `setup_fake_db.py` script is used to create a fake database instance and fill it with fake data.
 
 ### Tests Included
 

--- a/tests/setup_fake_db.py
+++ b/tests/setup_fake_db.py
@@ -19,8 +19,8 @@ Creation:
 @Date: 2024-05-07
 """
 
-import logging
 from new_arrivals_chi.app.main import create_app, db
+from new_arrivals_chi.app.utils import setup_logger
 from db_test import create_fake_data
 
 
@@ -32,8 +32,8 @@ def main():
     Returns:
         None; logs the completion of fake data generation.
     """
-    logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger("FakeDataCreator")
+    logger = setup_logger("FakeDataCreator")
+    logger.info("Starting the application setup for fake data creation.")
 
     app = create_app(
         {

--- a/tests/setup_fake_db.py
+++ b/tests/setup_fake_db.py
@@ -1,3 +1,22 @@
+"""Project: New Arrivals Chicago
+
+File name: create_fake_data.py
+Associated Files: main.py, database.py, db_test.py
+
+This script initializes a Flask application and uses it to generate fake data for testing by invoking functions defined in db_test.py.
+
+Methods:
+    * main — Sets up logging, initializes the Flask application, creates the database, and generates fake data.
+
+Last updated:
+@Author: Aaron Haefner @aaronhaefner
+@Date: 2024-05-07
+
+Creation:
+@Author: Aaron Haefner @aaronhaefner
+@Date: 2024-05-07
+"""
+
 import logging
 from flask import Flask
 from new_arrivals_chi.app.main import create_app, db
@@ -5,16 +24,22 @@ from new_arrivals_chi.app.database import User, Organization, Location, Hours
 from db_test import create_fake_data
 
 def main():
+    """
+    Main function to initialize logging, create a Flask application, set up the database,
+    and generate fake data using the create_fake_data function from db_test.
+
+    Returns:
+        None; logs the completion of fake data generation.
+    """
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('FakeDataCreator')
 
     app = create_app({
         'TESTING': True,
-        'SQLALCHEMY_DATABASE_URI': 'sqlite:///./test_fake_data.db',  # Ensure this points to a test DB
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///./test_fake_data.db',
         'SQLALCHEMY_TRACK_MODIFICATIONS': False
     })
 
-    # Run within the application context
     with app.app_context():
         db.create_all()
 

--- a/tests/setup_fake_db.py
+++ b/tests/setup_fake_db.py
@@ -3,10 +3,12 @@
 File name: create_fake_data.py
 Associated Files: main.py, database.py, db_test.py
 
-This script initializes a Flask application and uses it to generate fake data for testing by invoking functions defined in db_test.py.
+This script initializes a Flask application and uses it to generate
+fake data for testing purposes.
 
 Methods:
-    * main — Sets up logging, initializes the Flask application, creates the database, and generates fake data.
+    * main — Sets up logging, initializes the Flask application,
+    creates the database, and generates fake data.
 
 Last updated:
 @Author: Aaron Haefner @aaronhaefner
@@ -18,27 +20,28 @@ Creation:
 """
 
 import logging
-from flask import Flask
 from new_arrivals_chi.app.main import create_app, db
-from new_arrivals_chi.app.database import User, Organization, Location, Hours
 from db_test import create_fake_data
+
 
 def main():
     """
-    Main function to initialize logging, create a Flask application, set up the database,
-    and generate fake data using the create_fake_data function from db_test.
+    Main function to initialize fake database
+    using the create_fake_data function from db_test.
 
     Returns:
         None; logs the completion of fake data generation.
     """
     logging.basicConfig(level=logging.INFO)
-    logger = logging.getLogger('FakeDataCreator')
+    logger = logging.getLogger("FakeDataCreator")
 
-    app = create_app({
-        'TESTING': True,
-        'SQLALCHEMY_DATABASE_URI': 'sqlite:///./test_fake_data.db',
-        'SQLALCHEMY_TRACK_MODIFICATIONS': False
-    })
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///./test_fake_data.db",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
     with app.app_context():
         db.create_all()
@@ -48,5 +51,6 @@ def main():
 
         logger.info("Fake data has been created successfully.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/setup_fake_db.py
+++ b/tests/setup_fake_db.py
@@ -1,0 +1,27 @@
+import logging
+from flask import Flask
+from new_arrivals_chi.app.main import create_app, db
+from new_arrivals_chi.app.database import User, Organization, Location, Hours
+from db_test import create_fake_data
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger('FakeDataCreator')
+
+    app = create_app({
+        'TESTING': True,
+        'SQLALCHEMY_DATABASE_URI': 'sqlite:///./test_fake_data.db',  # Ensure this points to a test DB
+        'SQLALCHEMY_TRACK_MODIFICATIONS': False
+    })
+
+    # Run within the application context
+    with app.app_context():
+        db.create_all()
+
+        num_users = 10
+        create_fake_data(num_users, db, logger)
+
+        logger.info("Fake data has been created successfully.")
+
+if __name__ == '__main__':
+    main()

--- a/tests/setup_fake_db.py
+++ b/tests/setup_fake_db.py
@@ -39,7 +39,6 @@ def main():
         {
             "TESTING": True,
             "SQLALCHEMY_DATABASE_URI": "sqlite:///./test_fake_data.db",
-            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
         }
     )
 


### PR DESCRIPTION
<!---
Please write your PR name in the present imperative tense. Examples of present imperative tense are:
"Fix issue in the dispatcher where…", "Improve our handling of…", etc."

For more information on Pull Requests, you can reference here:
https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute
-->
## Describe your changes

This PR adds the `tests/setup_fake_db.py` script to the repo. The script can be executed with `poetry run python3 setup_fake_db.py`.

After successfully running the script, the user should have a folder called `instance` in the top level directory and a `test_fake_data.db` instance containing the fake data. Closes #34.

## Non-obvious technical information

The `pre-commit-config.yaml` file was edited to exclude a testing hook for this specific script, i.e., exclude "test" from the script name. The script is also excluded from being executed every time `pytest` is run by adding configuration rules to the `pyproject.toml` file.

## Checklist before requesting a review
- [x] pre-commit run --all-files (run before pushing)
- [x] pytest if applicable
- [x] Link issue
- [x] Update relevant documentation if applicable: doc strings, readme, poetry.
