### PR TITLE
Fixing redirecting to esp page

### DIFF
--- a/new_arrivals_chi/app/main.py
+++ b/new_arrivals_chi/app/main.py
@@ -23,8 +23,7 @@ Creation:
 
 from http import HTTPMethod
 
-from flask import Flask, Blueprint, render_template, request, current_app, \
-                  flash, request, jsonify, session
+from flask import Flask, Blueprint, render_template, request, current_app, flash
 from markupsafe import escape
 import os
 import bleach
@@ -170,12 +169,6 @@ def info():
     return render_template(
         "info.html", language=language, translations=translations
     )
-
-@main.route('/change-language', methods=['POST'])
-def change_language():
-    new_language = request.args.get(KEY_TRANSLATIONS)
-    session['language'] = new_language  # Update session with the new language
-    return jsonify(success=True)
 
 
 def create_app(config_override=None):

--- a/new_arrivals_chi/app/main.py
+++ b/new_arrivals_chi/app/main.py
@@ -23,7 +23,8 @@ Creation:
 
 from http import HTTPMethod
 
-from flask import Flask, Blueprint, render_template, request, current_app, flash
+from flask import Flask, Blueprint, render_template, request, current_app, \
+                  flash, request, jsonify, session
 from markupsafe import escape
 import os
 import bleach
@@ -169,6 +170,12 @@ def info():
     return render_template(
         "info.html", language=language, translations=translations
     )
+
+@main.route('/change-language', methods=['POST'])
+def change_language():
+    new_language = request.args.get(KEY_TRANSLATIONS)
+    session['language'] = new_language  # Update session with the new language
+    return jsonify(success=True)
 
 
 def create_app(config_override=None):

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,7 +42,7 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 
 <form id="languageForm" action="/" method="GET">
-    <button type="submit" class="language-button">{{ 'English' if language == 'es' else 'Español' | escape  }}</button>
+    <button type="submit" class="language-button">{{'English' if language == 'es' else 'Español' | escape }}</button>
     <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'es' | escape }}">
 </form>
 

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -41,7 +41,6 @@ Madeleine Roberts @MadeleineKRoberts
         {% endif %}
     </nav>
 
-
 <form id="languageForm" action="/" method="GET">
     <button type="button" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
         {% if language == 'es' %}
@@ -62,9 +61,6 @@ Madeleine Roberts @MadeleineKRoberts
     <a href="/report-error">{{ translations[language]['base']['report_error'] | escape }}</a> <i class="fas fa-bug"></i>
 </p>
 
-
-
-
 <script>
     function navigateTo(destination, language) {
         window.location.href = destination + '?lang=' + language;
@@ -83,10 +79,10 @@ Madeleine Roberts @MadeleineKRoberts
             window.location.href = '/login?lang=' + newLanguage;
         } else if (currentPageURL.includes('/signup')) {
             window.location.href = '/signup?lang=' + newLanguage;
-        } else if (currentPageURL.includes('/')) {  // Include the home page
+        } else if (currentPageURL.includes('/')) {
             window.location.href = '/?lang=' + newLanguage;
         }
-         // Add more conditions for pages that may be developed
+         // Add future pages here that need to switch b/w English + Spanish
 
         const languageButton = document.querySelector('.language-button');
         languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,16 +42,13 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 </body>
 
-<form action="/" method="GET">
-    <button type="submit" class="language-button">
-        {% if language == 'es' %}
-            English
-        {% else %}
-            Español
-        {% endif %}
-    </button>
-    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
-</form>
+<button type="button" onclick="changeLanguage('{{ language }}')">
+    {% if language == 'en' %}
+        Español
+    {% else %}
+        English
+    {% endif %}
+</button>
 
 <div class="container has-text-centered">
     {% block content %}
@@ -66,7 +63,24 @@ Madeleine Roberts @MadeleineKRoberts
 
 
 <script>
-    function navigateTo(destination, language) {
-        window.location.href = destination + '?lang=' + language;
+    function changeLanguage(currentLanguage) {
+        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+
+        fetch(`/change-language?lang=${newLanguage}`, { method: 'POST' })
+            .then(response => {
+                if (response.ok) {
+                    return response.json();
+                }
+                throw new Error('Network response was not ok.');
+            })
+            .then(data => {
+                if (data.success) {
+                    location.reload(); // Reload the page after language change
+                } else {
+                    console.error('Error changing language:', data.error);
+                }
+            })
+            .catch(error => console.error('Error changing language:', error));
     }
 </script>
+

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,7 +42,7 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 
 <form id="languageForm" action="/" method="GET">
-    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <button type="submit" class="language-button">{{ 'English' if language == 'es' else 'Español' | escape  }}</button>
     <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'es' | escape }}">
 </form>
 

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -71,30 +71,27 @@ Madeleine Roberts @MadeleineKRoberts
     }
 
     function changeLanguage(currentLanguage) {
-    console.log('Changing language to:', currentLanguage);
-    const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
 
-    // Update text on the language toggle button
-    const languageButton = document.querySelector('.language-button');
-    languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+        // Update the hidden input value
+        const languageInput = document.querySelector('input[name="lang"]');
+        languageInput.value = newLanguage;
 
-    // Update all elements with translations
-    document.querySelectorAll('.translate').forEach(element => {
-        const key = element.dataset.key;
-        console.log('Translating key:', key);
-        const translatedText = translations[newLanguage]['base'][key];
-        console.log('Translated text:', translatedText);
-        element.innerText = translatedText;
-    });
+        // Update the language attribute in the HTML tag
+        document.querySelector('html').setAttribute('lang', newLanguage);
 
-    // Update the hidden input value
-    const languageInput = document.querySelector('input[name="lang"]');
-    languageInput.value = newLanguage;
+        // Redirect to the translated page if currently on a specific page
+        const currentPageURL = window.location.pathname;
+        if (currentPageURL.includes('/login')) {
+            window.location.href = '/login?lang=' + newLanguage;
+        } else if (currentPageURL.includes('/signup')) {
+            window.location.href = '/signup?lang=' + newLanguage;
+        } // Add more conditions for other pages as needed
 
-    // Update the language attribute in the HTML tag
-    document.querySelector('html').setAttribute('lang', newLanguage);
-}
-
+        // Update text on the language toggle button after redirection
+        const languageButton = document.querySelector('.language-button');
+        languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+    }
 </script>
 
 </body>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -43,7 +43,7 @@ Madeleine Roberts @MadeleineKRoberts
 </body>
 
 <form action="/" method="GET">
-    <button type="submit" class="language-button">
+    <button type="submit" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
         {% if language == 'es' %}
             English
         {% else %}

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -83,6 +83,8 @@ Madeleine Roberts @MadeleineKRoberts
 
             // Update the language attribute in the HTML tag
             document.querySelector('html').setAttribute('lang', newLanguage);
+
+            return false;
         }
     </script>
 </script>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -70,9 +70,25 @@ Madeleine Roberts @MadeleineKRoberts
         window.location.href = destination + '?lang=' + language;
     }
 
-    function changeLanguage(newLanguage) {
+    function changeLanguage(currentLanguage) {
+        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+
+        // Update text on the language toggle button
         const languageButton = document.querySelector('.language-button');
         languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+
+        // Update all elements with translations
+        document.querySelectorAll('.translate').forEach(element => {
+            const key = element.dataset.key;
+            const translatedText = translations[newLanguage]['base'][key];
+            element.innerText = translatedText;
+        });
+
+        // Update the hidden input value
+        const languageInput = document.querySelector('input[name="lang"]');
+        languageInput.value = newLanguage;
+
+        // Update the language attribute in the HTML tag
         document.querySelector('html').setAttribute('lang', newLanguage);
     }
 </script>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -71,26 +71,30 @@ Madeleine Roberts @MadeleineKRoberts
     }
 
     function changeLanguage(currentLanguage) {
-        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+    console.log('Changing language to:', currentLanguage);
+    const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
 
-        // Update text on the language toggle button
-        const languageButton = document.querySelector('.language-button');
-        languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+    // Update text on the language toggle button
+    const languageButton = document.querySelector('.language-button');
+    languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
 
-        // Update all elements with translations
-        document.querySelectorAll('.translate').forEach(element => {
-            const key = element.dataset.key;
-            const translatedText = translations[newLanguage]['base'][key];
-            element.innerText = translatedText;
-        });
+    // Update all elements with translations
+    document.querySelectorAll('.translate').forEach(element => {
+        const key = element.dataset.key;
+        console.log('Translating key:', key);
+        const translatedText = translations[newLanguage]['base'][key];
+        console.log('Translated text:', translatedText);
+        element.innerText = translatedText;
+    });
 
-        // Update the hidden input value
-        const languageInput = document.querySelector('input[name="lang"]');
-        languageInput.value = newLanguage;
+    // Update the hidden input value
+    const languageInput = document.querySelector('input[name="lang"]');
+    languageInput.value = newLanguage;
 
-        // Update the language attribute in the HTML tag
-        document.querySelector('html').setAttribute('lang', newLanguage);
-    }
+    // Update the language attribute in the HTML tag
+    document.querySelector('html').setAttribute('lang', newLanguage);
+}
+
 </script>
 
 </body>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -70,25 +70,12 @@ Madeleine Roberts @MadeleineKRoberts
         window.location.href = destination + '?lang=' + language;
     }
 
-    function changeLanguage(currentLanguage) {
-            const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
-
-            // Update text on the language toggle button
-            const languageButton = document.querySelector('.language-button');
-            languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
-
-            // Update the hidden input value
-            const languageInput = document.querySelector('input[name="lang"]');
-            languageInput.value = newLanguage;
-
-            // Update the language attribute in the HTML tag
-            document.querySelector('html').setAttribute('lang', newLanguage);
-
-            // Prevent form submission (prevents redirection)
-            document.getElementById('languageForm').addEventListener('submit', function(event) {
-                event.preventDefault();
-            });
-        }
+    function changeLanguage(newLanguage) {
+        const languageButton = document.querySelector('.language-button');
+        languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+        document.querySelector('html').setAttribute('lang', newLanguage);
+    }
 </script>
+
 </body>
 </html>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -71,24 +71,23 @@ Madeleine Roberts @MadeleineKRoberts
     }
 
     function changeLanguage(currentLanguage) {
-        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+        const newLanguage = currentLanguage === 'en' ? 'es' : 'en';
 
-        // Update the hidden input value
         const languageInput = document.querySelector('input[name="lang"]');
         languageInput.value = newLanguage;
 
-        // Update the language attribute in the HTML tag
         document.querySelector('html').setAttribute('lang', newLanguage);
 
-        // Redirect to the translated page if currently on a specific page
         const currentPageURL = window.location.pathname;
         if (currentPageURL.includes('/login')) {
             window.location.href = '/login?lang=' + newLanguage;
         } else if (currentPageURL.includes('/signup')) {
             window.location.href = '/signup?lang=' + newLanguage;
-        } // Add more conditions for other pages as needed
+        } else if (currentPageURL.includes('/')) {  // Include the home page
+            window.location.href = '/?lang=' + newLanguage;
+        }
+         // Add more conditions for pages that may be developed
 
-        // Update text on the language toggle button after redirection
         const languageButton = document.querySelector('.language-button');
         languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
     }

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,13 +42,16 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 </body>
 
-<button type="button" onclick="changeLanguage('{{ language }}')">
-    {% if language == 'en' %}
-        Español
-    {% else %}
-        English
-    {% endif %}
-</button>
+<form action="/" method="GET">
+    <button type="submit" class="language-button">
+        {% if language == 'es' %}
+            English
+        {% else %}
+            Español
+        {% endif %}
+    </button>
+    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
+</form>
 
 <div class="container has-text-centered">
     {% block content %}
@@ -63,24 +66,24 @@ Madeleine Roberts @MadeleineKRoberts
 
 
 <script>
-    function changeLanguage(currentLanguage) {
-        const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
-
-        fetch(`/change-language?lang=${newLanguage}`, { method: 'POST' })
-            .then(response => {
-                if (response.ok) {
-                    return response.json();
-                }
-                throw new Error('Network response was not ok.');
-            })
-            .then(data => {
-                if (data.success) {
-                    location.reload(); // Reload the page after language change
-                } else {
-                    console.error('Error changing language:', data.error);
-                }
-            })
-            .catch(error => console.error('Error changing language:', error));
+    function navigateTo(destination, language) {
+        window.location.href = destination + '?lang=' + language;
     }
-</script>
 
+    function changeLanguage(currentLanguage) {
+            const newLanguage = currentLanguage === 'en' ? 'es' : 'en'; // Toggle between English and Spanish
+
+            // Update text on the language toggle button
+            const languageButton = document.querySelector('.language-button');
+            languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
+
+            // Update the hidden input value
+            const languageInput = document.querySelector('input[name="lang"]');
+            languageInput.value = newLanguage;
+
+            // Update the language attribute in the HTML tag
+            document.querySelector('html').setAttribute('lang', newLanguage);
+        }
+    </script>
+</script>
+   

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -40,7 +40,7 @@ Madeleine Roberts @MadeleineKRoberts
         <button onclick="navigateTo('/signup', '{{ language | escape }}')" class="navbar-item">{{ translations[language]['base']['sign_up'] | escape }}</button>
         {% endif %}
     </nav>
-</body>
+
 
 <form id="languageForm" action="/" method="GET">
     <button type="button" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
@@ -62,7 +62,7 @@ Madeleine Roberts @MadeleineKRoberts
     <a href="/report-error">{{ translations[language]['base']['report_error'] | escape }}</a> <i class="fas fa-bug"></i>
 </p>
 
-</html>
+
 
 
 <script>
@@ -90,4 +90,5 @@ Madeleine Roberts @MadeleineKRoberts
             });
         }
 </script>
-   
+</body>
+</html>

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,8 +42,8 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 </body>
 
-<form action="/" method="GET">
-    <button type="submit" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
+<form id="languageForm" action="/" method="GET">
+    <button type="button" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
         {% if language == 'es' %}
             English
         {% else %}
@@ -84,8 +84,10 @@ Madeleine Roberts @MadeleineKRoberts
             // Update the language attribute in the HTML tag
             document.querySelector('html').setAttribute('lang', newLanguage);
 
-            return false;
+            // Prevent form submission (prevents redirection)
+            document.getElementById('languageForm').addEventListener('submit', function(event) {
+                event.preventDefault();
+            });
         }
-    </script>
 </script>
    

--- a/new_arrivals_chi/app/templates/base.html
+++ b/new_arrivals_chi/app/templates/base.html
@@ -42,15 +42,10 @@ Madeleine Roberts @MadeleineKRoberts
     </nav>
 
 <form id="languageForm" action="/" method="GET">
-    <button type="button" class="language-button" onclick="changeLanguage('{{ language | escape }}')">
-        {% if language == 'es' %}
-            English
-        {% else %}
-            Español
-        {% endif %}
-    </button>
-    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
+    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'es' | escape }}">
 </form>
+
 
 <div class="container has-text-centered">
     {% block content %}
@@ -64,28 +59,6 @@ Madeleine Roberts @MadeleineKRoberts
 <script>
     function navigateTo(destination, language) {
         window.location.href = destination + '?lang=' + language;
-    }
-
-    function changeLanguage(currentLanguage) {
-        const newLanguage = currentLanguage === 'en' ? 'es' : 'en';
-
-        const languageInput = document.querySelector('input[name="lang"]');
-        languageInput.value = newLanguage;
-
-        document.querySelector('html').setAttribute('lang', newLanguage);
-
-        const currentPageURL = window.location.pathname;
-        if (currentPageURL.includes('/login')) {
-            window.location.href = '/login?lang=' + newLanguage;
-        } else if (currentPageURL.includes('/signup')) {
-            window.location.href = '/signup?lang=' + newLanguage;
-        } else if (currentPageURL.includes('/')) {
-            window.location.href = '/?lang=' + newLanguage;
-        }
-         // Add future pages here that need to switch b/w English + Spanish
-
-        const languageButton = document.querySelector('.language-button');
-        languageButton.innerText = newLanguage === 'en' ? 'Español' : 'English';
     }
 </script>
 

--- a/new_arrivals_chi/app/templates/login.html
+++ b/new_arrivals_chi/app/templates/login.html
@@ -16,7 +16,7 @@ Creation:
 {% extends "base.html" %}
 {% block content %}
 <form action="/login" method="GET">
-    <button type="submit" class="language-button">{{ translations[language] if language == 'es' else 'Español' | escape }}</button>
+    <button type="submit" class="language-button">{{ 'English' if language == 'es' else 'Español' | escape }}</button>
     <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
 </form>
 <div >

--- a/new_arrivals_chi/app/templates/login.html
+++ b/new_arrivals_chi/app/templates/login.html
@@ -15,6 +15,10 @@ Creation:
 
 {% extends "base.html" %}
 {% block content %}
+<form action="/login" method="GET">
+    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
+</form>
 <div >
     <h3 class="title">{{ translations[language]['util']['login'] | escape }}</h3>
     <div class="box">

--- a/new_arrivals_chi/app/templates/login.html
+++ b/new_arrivals_chi/app/templates/login.html
@@ -16,7 +16,7 @@ Creation:
 {% extends "base.html" %}
 {% block content %}
 <form action="/login" method="GET">
-    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <button type="submit" class="language-button">{{ translations[language] if language == 'es' else 'Español' | escape }}</button>
     <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
 </form>
 <div >

--- a/new_arrivals_chi/app/templates/signup.html
+++ b/new_arrivals_chi/app/templates/signup.html
@@ -15,6 +15,10 @@ Creation:
 
 {% extends "base.html" %}
 {% block content %}
+<form action="/signup" method="GET">
+    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
+</form>
 
 <div class="column is-4 is-offset-4">
     <div class="box">

--- a/new_arrivals_chi/app/templates/signup.html
+++ b/new_arrivals_chi/app/templates/signup.html
@@ -16,7 +16,7 @@ Creation:
 {% extends "base.html" %}
 {% block content %}
 <form action="/signup" method="GET">
-    <button type="submit" class="language-button">{{ translations[language]['util']['language'] | escape }}</button>
+    <button type="submit" class="language-button">{{ 'English' if language == 'es' else 'Español' | escape }}</button>
     <input type="hidden" name="lang" value="{{ 'es' if language == 'en' else 'en' | escape }}">
 </form>
 

--- a/tests/xss_test.py
+++ b/tests/xss_test.py
@@ -18,13 +18,12 @@ Creation:
 
 
 def test_xss_script_tag_injection(client, setup_logger):
-    """""
-    Test the resistance of the change password form to XSS attacks.
+    """Test the resistance of the change password form to XSS attacks.
 
     Attempt to inject a script tag into the new password fields. This test
     ensures that script tags submitted through the change password form are
     properly escaped or removed.
-    """ ""
+    """
     logger = setup_logger("test_xss_script_tag_injection")
 
     try:


### PR DESCRIPTION
<!---
Please write your PR name in the present imperative tense. Examples of present imperative tense are:
"Fix issue in the dispatcher where…", "Improve our handling of…", etc."

For more information on Pull Requests, you can reference here:
https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute
-->
## Describe your changes

This will close #100. I previously didn't understand Summer's original ask, which was .... when a users clicks login> clicks spanish --> the user is re-directed back to home page. Instead the user should stay on login page but the page should be translated w.o/redirecting. 

What i did:

- Added a function to help deal with this and update language translation button.
- i also was receiving a pre-commit error because of a docstring in xss test so i updated the quotes on that to make it 3 quotes on each side

See video to see how it works.

https://github.com/uchicago-capp-30320/new-arrivals-chi/assets/114881443/acaf3f77-9267-42e1-959f-55a675bae06c


## Non-obvious technical information


## Checklist before requesting a review
- [ X] pre-commit run --all-files (run before pushing)
- [ X] pytest if applicable
- [ X] Link issue
- [ X] Update relevant documentation if applicable: doc strings, readme, poetry.


