### PR TITLE
(bug) Fix button path to edit_organization from organization dashboard

### DIFF
--- a/new_arrivals_chi/app/authorize_routes.py
+++ b/new_arrivals_chi/app/authorize_routes.py
@@ -464,7 +464,7 @@ def toggle_suspend_organization(organization_id):
 
 
 @authorize.route(
-    "/admin/edit_organization/<int:organization_id>", methods=["GET", "POST"]
+    "/admin/edit_organization/<int:organization_id>", methods=["GET"]
 )
 @admin_required
 def admin_edit_organization(organization_id):
@@ -482,9 +482,6 @@ def admin_edit_organization(organization_id):
 
     organization = Organization.query.get(organization_id)
 
-    if request.method == "POST":
-        # Handle the form submission
-        pass
     return render_template(
         "edit_organization.html",
         organization_id=organization_id,

--- a/new_arrivals_chi/app/languages/en.json
+++ b/new_arrivals_chi/app/languages/en.json
@@ -367,10 +367,10 @@
       "welcome": "Welcome to Chicago!"
     },
     "info": {
-      "languages_spoken": "Languages Spoken: English, Spanish",
-      "open_hours": "Open Hours: Monday - Friday, 9:00 AM - 5:00 PM",
+      "languages_spoken": "Languages Spoken",
+      "open_hours": "Open Hours",
       "organization_name": "Organization Name",
-      "supplies_and_services": "Supplies and Services: Food"
+      "supplies_and_services": "Supplies and Services"
     },
     "lawyers": {
       "content": [

--- a/new_arrivals_chi/app/languages/es.json
+++ b/new_arrivals_chi/app/languages/es.json
@@ -367,10 +367,10 @@
       "welcome": "\u00a1Bienvenido a Chicago!"
     },
     "info": {
-      "languages_spoken": "Idiomas hablados: English, Spanish",
-      "open_hours": "Horas de Atenci\u00f3n: Lunes - Viernes, 9:00 AM - 5:00 PM",
+      "languages_spoken": "Idiomas hablados",
+      "open_hours": "Horas de Atenci\u00f3n",
       "organization_name": "Nombre de la Organizaci\u00f3n",
-      "supplies_and_services": "Recursos y Servicios: Comida"
+      "supplies_and_services": "Recursos y Servicios"
     },
     "lawyers": {
       "content": [

--- a/new_arrivals_chi/app/main.py
+++ b/new_arrivals_chi/app/main.py
@@ -465,7 +465,7 @@ def org(organization_id):
     )
 
 
-@main.route("/edit_organization/<int:organization_id>", methods=["GET"])
+@main.route("/edit_organization/<int:organization_id>", methods=["GET", "POST"])
 @login_required
 def edit_organization(organization_id):
     """Establishes route to the edit organization page.
@@ -480,15 +480,14 @@ def edit_organization(organization_id):
     language = bleach.clean(request.args.get(KEY_LANGUAGE, DEFAULT_LANGUAGE))
     translations = current_app.config[KEY_TRANSLATIONS][language]
 
-    user = current_user
-    organization = extract_organization(user.organization_id)
+    organization = Organization.query.get(organization_id)
 
     return render_template(
         "edit_organization.html",
+        organization_id=organization_id,
         organization=organization,
         language=language,
         translations=translations,
-        organization_id=organization_id,
     )
 
 

--- a/new_arrivals_chi/app/main.py
+++ b/new_arrivals_chi/app/main.py
@@ -465,7 +465,7 @@ def org(organization_id):
     )
 
 
-@main.route("/edit_organization/<int:organization_id>", methods=["GET", "POST"])
+@main.route("/edit_organization/<int:organization_id>", methods=["GET"])
 @login_required
 def edit_organization(organization_id):
     """Establishes route to the edit organization page.

--- a/new_arrivals_chi/app/templates/dashboard.html
+++ b/new_arrivals_chi/app/templates/dashboard.html
@@ -17,7 +17,7 @@ HTML for organization dashboard page.
         <button class="button button-blue" onclick="navigateTo('{{ url_for('main.org', organization_id=organization.id) }}', '{{ language }}')">
             {{ translations[language]['profile']['view_org_page'] | escape }}
         </button>
-        <button class="button button-green" onclick="navigateTo('{{ url_for('main.dashboard') }}', '{{ language }}')">
+        <button class="button button-green" onclick="navigateTo('{{ url_for('main.edit_organization', organization_id=organization.id) }}', '{{ language }}')">
             {{ translations[language]['profile']['update_org_info'] | escape }}
         </button>
         <button class="button button-orange" onclick="navigateTo('{{ url_for('authorize.change_password') }}', '{{ language }}')">


### PR DESCRIPTION
## Describe your changes
This PR will close #259

- Changes how the organization is retrieved (from the Org ID rather than current user). This approach aligns with how the similar task is performed in the admin dashboard
- Updates translation JSON to remove hardcoding of org resources 
- Remove unused post requests in edit_organization and authorize.edit_organization

## Non-obvious technical information

This bug was a result of how Organization was accessed and passed into `edit_organization.html`. The bug has been resolved by passing organization_id as a parameter, rather than extracting it in relation to the current user.


## Checklist before requesting a review
- [X] pre-commit run --all-files (run before pushing)
- [X] pytest if applicable
- [X] Link issue
- [X] Update relevant documentation if applicable: doc strings, readme, poetry.


